### PR TITLE
Chore: set resrouce_class for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
           command: npm run lint
   spec:
     executor: default
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_my_workspace


### PR DESCRIPTION
## TODOs

- [x] set `resource_class`
  - [x] set jobs under minute to small
  - [x] set jobs over minute to medium

|Before|After|
|---|---|
|https://app.circleci.com/pipelines/github/zenoplex/react-hooks/121/workflows/9006f356-f8a0-4750-a66b-182980eb71f2|https://app.circleci.com/pipelines/github/zenoplex/react-hooks/125/workflows/45b57a8d-bc97-45ed-a059-daa806794883|
|<img alt="CleanShot 2023-05-05 at 20 45 13@2x" src="https://user-images.githubusercontent.com/4514921/236449682-bd176e40-cb76-49e8-b947-f97db3f9b128.png">|![CleanShot 2023-05-05 at 20 45 57@2x](https://user-images.githubusercontent.com/4514921/236449662-4d83f59e-c61e-408e-ab6a-96b0f9ac5150.png)|


