### PR TITLE
Chore: set maxWorkers to two

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ jobs:
           command: wget --tries 600 --waitretry 1 --retry-connrefused --timeout 300 -O /dev/null http://localhost:6006
       - run:
           name: Run storybook tests
-          command: npm run test:storybook -w workshop
+          command: npm run test:storybook -w workshop -- --maxWorkers=2
   vrt:
     executor: default
     resource_class: medium


### PR DESCRIPTION
## Description

Set `maxWorkers` option since test might be flaky on CI when number of spec increases.

## TODOs

- [x] `maxWorkers=2` on ci

After settings maxWorkers, I'm not seeing long execution warning anymore.

|Before|After|
|---|---|
|https://app.circleci.com/pipelines/github/zenoplex/react-hooks/174/workflows/ec23dab1-e3c6-4272-a806-293752436331/jobs/1232|https://app.circleci.com/pipelines/github/zenoplex/react-hooks/175/workflows/f427930c-8ce8-4199-bcb9-8d65f8ddd154/jobs/1239|
|<img width="776" alt="CleanShot 2023-05-09 at 00 27 05@2x" src="https://user-images.githubusercontent.com/4514921/236864931-db4063ac-80b7-4091-9fce-97a57d4a6cb8.png">|<img width="664" alt="CleanShot 2023-05-09 at 00 27 12@2x" src="https://user-images.githubusercontent.com/4514921/236864976-beaf27f0-a7be-4092-a95b-ae3bcc98548e.png">|


