### PR TITLE
chore: update vite swc plugin

### DIFF
--- a/apps/workshop/package.json
+++ b/apps/workshop/package.json
@@ -31,7 +31,7 @@
     "@storybook/testing-library": "0.1.0",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
-    "@vitejs/plugin-react-swc": "^3.0.0",
+    "@vitejs/plugin-react-swc": "3.3.1",
     "autoprefixer": "10.4.14",
     "postcss": "8.4.23",
     "prop-types": "^15.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "@storybook/testing-library": "0.1.0",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
-        "@vitejs/plugin-react-swc": "^3.0.0",
+        "@vitejs/plugin-react-swc": "3.3.1",
         "autoprefixer": "10.4.14",
         "postcss": "8.4.23",
         "prop-types": "^15.8.1",
@@ -7399,9 +7399,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.49.tgz",
-      "integrity": "sha512-br44ZHOfE9YyRGcORSLkHFQHTvhwRcaithBJ1Q5y5iMGpLbH0Wai3GN49L60RvmGwxNJfWzT+E7+rNNR7ewKgA==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.59.tgz",
+      "integrity": "sha512-ZBw31zd2E5SXiodwGvjQdx5ZC90b2uyX/i2LeMMs8LKfXD86pfOfQac+JVrnyEKDhASXj9icgsF9NXBhaMr3Kw==",
       "dev": true,
       "hasInstallScript": true,
       "engines": {
@@ -7412,16 +7412,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.49",
-        "@swc/core-darwin-x64": "1.3.49",
-        "@swc/core-linux-arm-gnueabihf": "1.3.49",
-        "@swc/core-linux-arm64-gnu": "1.3.49",
-        "@swc/core-linux-arm64-musl": "1.3.49",
-        "@swc/core-linux-x64-gnu": "1.3.49",
-        "@swc/core-linux-x64-musl": "1.3.49",
-        "@swc/core-win32-arm64-msvc": "1.3.49",
-        "@swc/core-win32-ia32-msvc": "1.3.49",
-        "@swc/core-win32-x64-msvc": "1.3.49"
+        "@swc/core-darwin-arm64": "1.3.59",
+        "@swc/core-darwin-x64": "1.3.59",
+        "@swc/core-linux-arm-gnueabihf": "1.3.59",
+        "@swc/core-linux-arm64-gnu": "1.3.59",
+        "@swc/core-linux-arm64-musl": "1.3.59",
+        "@swc/core-linux-x64-gnu": "1.3.59",
+        "@swc/core-linux-x64-musl": "1.3.59",
+        "@swc/core-win32-arm64-msvc": "1.3.59",
+        "@swc/core-win32-ia32-msvc": "1.3.59",
+        "@swc/core-win32-x64-msvc": "1.3.59"
       },
       "peerDependencies": {
         "@swc/helpers": "^0.5.0"
@@ -7433,9 +7433,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.49.tgz",
-      "integrity": "sha512-g7aIfXh6uPHmhLXdjXQq5t3HAyS/EdvujasW1DIS5k8UqOBaSoCcSGtLIjzcLv3KujqNfYcm118E+12H0nY6fQ==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.59.tgz",
+      "integrity": "sha512-AnqWFBgEKHP0jb4iZqx7eVQT9/rX45+DE4Ox7GpwCahUKxxrsDLyXzKhwLwQuAjUvtu5JcSB77szKpPGDM49fQ==",
       "cpu": [
         "arm64"
       ],
@@ -7450,9 +7450,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.49.tgz",
-      "integrity": "sha512-eSIxVX0YDw40Bre5sAx2BV3DzdIGzmQvCf2yiBvLqiiL6GC0mmuDeWbUCAzdUX6fJ6FUVEBMUVqNOc9oJ2/d5w==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.59.tgz",
+      "integrity": "sha512-iqDs+yii9mOsmpJez82SEi4d4prWDRlapHxKnDVJ0x1AqRo41vIq8t3fujrvCHYU5VQgOYGh4ooXQpaP2H3B2A==",
       "cpu": [
         "x64"
       ],
@@ -7467,9 +7467,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.49.tgz",
-      "integrity": "sha512-8mj3IcRVr/OJY0mVITz6Z5osNAMJK5GiKDaZ+3QejPLbl6aiu4sH4GmTHDRN14RnaVXOpecsGcUoQmNoNa3u3w==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.59.tgz",
+      "integrity": "sha512-PB0PP+SgkCSd/kYmltnPiGv42cOSaih1OjXCEjxvNwUFEmWqluW6uGdWaNiR1LoYMxhcHZTc336jL2+O3l6p0Q==",
       "cpu": [
         "arm"
       ],
@@ -7484,9 +7484,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.49.tgz",
-      "integrity": "sha512-Rmg9xw6tmpOpf6GKKjpHQGmjfHzqSths5ebI2ahrHlhekzZF2HYmPkVw4bHda8Bja6mbaw8FVBgBHjPU8mMeDA==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.59.tgz",
+      "integrity": "sha512-Ol/JPszWZ+OZ44FOdJe35TfJ1ckG4pYaisZJ4E7PzfwfVe2ygX85C5WWR4e5L0Y1zFvzpcI7gdyC2wzcXk4Cig==",
       "cpu": [
         "arm64"
       ],
@@ -7501,9 +7501,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.49.tgz",
-      "integrity": "sha512-nlKPYMogAI3Aak6Mlkag8/2AlHAZ/DpH7RjhfMazsaGhD/sQOmYdyY9Al69ejpa419YJuREeeeLoojFlSsd30g==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.59.tgz",
+      "integrity": "sha512-PtTTtGbj9GiY5gJdoSFL2A0vL6BRaS1haAhp6g3hZvLDkTTg+rJURmzwBMMjaQlnGC62x/lLf6MoszHG/05//Q==",
       "cpu": [
         "arm64"
       ],
@@ -7518,9 +7518,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.49.tgz",
-      "integrity": "sha512-QOyeJQ6NVi73SJcizbwvIZTiGA/N+BxX9liRrvibumaQmRh8fWjJiLNsv3ODSHeuonak7E8Bf7a7NnSTyu48Mw==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.59.tgz",
+      "integrity": "sha512-XBW9AGi0YsIN76IfesnDSBn/5sjR69J75KUNte8sH6seYlHJ0/kblqUMbUcfr0CiGoJadbzAZeKZZmfN7EsHpg==",
       "cpu": [
         "x64"
       ],
@@ -7535,9 +7535,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.49.tgz",
-      "integrity": "sha512-WlDMz+SOpYC9O/ZBUw1oiyWI7HyUCMlf/HS8Fy/kRI3eGoGCUxVTCJ1mP57GdQr4Wg32Y/ZpO2KSNQFWnT8mAw==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.59.tgz",
+      "integrity": "sha512-Cy5E939SdWPQ34cg6UABNO0RyEe0FuWqzZ/GLKtK11Ir4fjttVlucZiY59uQNyUVUc8T2qE0VBFCyD/zYGuHtg==",
       "cpu": [
         "x64"
       ],
@@ -7552,9 +7552,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.49.tgz",
-      "integrity": "sha512-41LZOeI94Za3twib8KOIjnHYAZ+nkBFmboaREsFR1760S7jiMVywqWX8nFZvn/CXj15Fjjgdgyuig+zMREwXwQ==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.59.tgz",
+      "integrity": "sha512-z5ZJxizRvRoSAaevRIi3YjQh74OFWEIhonSDWNdqDL7RbjEivcatYcG7OikH6s+rtPhOcwNm3PbGV2Prcgh/gg==",
       "cpu": [
         "arm64"
       ],
@@ -7569,9 +7569,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.49.tgz",
-      "integrity": "sha512-IdqLPoMKssyAoOCZdNXmnAd6/uyx+Hb9KSfZUHepZaNfwMy6J5XXrOsbYs3v53FH8MtekUUdV+mMX4me9bcv9w==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.59.tgz",
+      "integrity": "sha512-vxpsn+hrKAhi5YusQfB/JXUJJVX40rIRE/L49ilBEqdbH8Khkoego6AD+2vWqTdJcUHo1WiAIAEZ0rTsjyorLQ==",
       "cpu": [
         "ia32"
       ],
@@ -7586,9 +7586,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.49.tgz",
-      "integrity": "sha512-7Fqjo5pS3uIohhSbYSaR0+e/bJdxmQb4oG97FIh5qvlCCGQaQ9UiaEeYy4uK0Ad+Menum1IXCAEiG7RHcl6Eyw==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.59.tgz",
+      "integrity": "sha512-Ris/cJbURylcLwqz4RZUUBCEGsuaIHOJsvf69W5pGKHKBryVoOTNhBKpo3Km2hoAi5qFQ/ou0trAT4hBsVPZvQ==",
       "cpu": [
         "x64"
       ],
@@ -9062,12 +9062,12 @@
       }
     },
     "node_modules/@vitejs/plugin-react-swc": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.3.0.tgz",
-      "integrity": "sha512-Ycg+n2eyCOTpn/wRy+evVo859+hw7qCj9iaX5CMny6x1fx1Uoq0xBG+a98lFtwLNGfGEnpI0F26YigRuxCRkwg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.3.1.tgz",
+      "integrity": "sha512-ZoYjGxMniXP7X+5ry/W1tpY7w0OeLUEsBF5RHFPmAhpgwwNWie8OF4056MRXRi9QgvYYoZPDzdOXGK3wlCoTfQ==",
       "dev": true,
       "dependencies": {
-        "@swc/core": "^1.3.42"
+        "@swc/core": "^1.3.56"
       },
       "peerDependencies": {
         "vite": "^4"
@@ -37503,99 +37503,99 @@
       }
     },
     "@swc/core": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.49.tgz",
-      "integrity": "sha512-br44ZHOfE9YyRGcORSLkHFQHTvhwRcaithBJ1Q5y5iMGpLbH0Wai3GN49L60RvmGwxNJfWzT+E7+rNNR7ewKgA==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.59.tgz",
+      "integrity": "sha512-ZBw31zd2E5SXiodwGvjQdx5ZC90b2uyX/i2LeMMs8LKfXD86pfOfQac+JVrnyEKDhASXj9icgsF9NXBhaMr3Kw==",
       "dev": true,
       "requires": {
-        "@swc/core-darwin-arm64": "1.3.49",
-        "@swc/core-darwin-x64": "1.3.49",
-        "@swc/core-linux-arm-gnueabihf": "1.3.49",
-        "@swc/core-linux-arm64-gnu": "1.3.49",
-        "@swc/core-linux-arm64-musl": "1.3.49",
-        "@swc/core-linux-x64-gnu": "1.3.49",
-        "@swc/core-linux-x64-musl": "1.3.49",
-        "@swc/core-win32-arm64-msvc": "1.3.49",
-        "@swc/core-win32-ia32-msvc": "1.3.49",
-        "@swc/core-win32-x64-msvc": "1.3.49"
+        "@swc/core-darwin-arm64": "1.3.59",
+        "@swc/core-darwin-x64": "1.3.59",
+        "@swc/core-linux-arm-gnueabihf": "1.3.59",
+        "@swc/core-linux-arm64-gnu": "1.3.59",
+        "@swc/core-linux-arm64-musl": "1.3.59",
+        "@swc/core-linux-x64-gnu": "1.3.59",
+        "@swc/core-linux-x64-musl": "1.3.59",
+        "@swc/core-win32-arm64-msvc": "1.3.59",
+        "@swc/core-win32-ia32-msvc": "1.3.59",
+        "@swc/core-win32-x64-msvc": "1.3.59"
       }
     },
     "@swc/core-darwin-arm64": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.49.tgz",
-      "integrity": "sha512-g7aIfXh6uPHmhLXdjXQq5t3HAyS/EdvujasW1DIS5k8UqOBaSoCcSGtLIjzcLv3KujqNfYcm118E+12H0nY6fQ==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.59.tgz",
+      "integrity": "sha512-AnqWFBgEKHP0jb4iZqx7eVQT9/rX45+DE4Ox7GpwCahUKxxrsDLyXzKhwLwQuAjUvtu5JcSB77szKpPGDM49fQ==",
       "dev": true,
       "optional": true,
       "peer": true
     },
     "@swc/core-darwin-x64": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.49.tgz",
-      "integrity": "sha512-eSIxVX0YDw40Bre5sAx2BV3DzdIGzmQvCf2yiBvLqiiL6GC0mmuDeWbUCAzdUX6fJ6FUVEBMUVqNOc9oJ2/d5w==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.59.tgz",
+      "integrity": "sha512-iqDs+yii9mOsmpJez82SEi4d4prWDRlapHxKnDVJ0x1AqRo41vIq8t3fujrvCHYU5VQgOYGh4ooXQpaP2H3B2A==",
       "dev": true,
       "optional": true,
       "peer": true
     },
     "@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.49.tgz",
-      "integrity": "sha512-8mj3IcRVr/OJY0mVITz6Z5osNAMJK5GiKDaZ+3QejPLbl6aiu4sH4GmTHDRN14RnaVXOpecsGcUoQmNoNa3u3w==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.59.tgz",
+      "integrity": "sha512-PB0PP+SgkCSd/kYmltnPiGv42cOSaih1OjXCEjxvNwUFEmWqluW6uGdWaNiR1LoYMxhcHZTc336jL2+O3l6p0Q==",
       "dev": true,
       "optional": true,
       "peer": true
     },
     "@swc/core-linux-arm64-gnu": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.49.tgz",
-      "integrity": "sha512-Rmg9xw6tmpOpf6GKKjpHQGmjfHzqSths5ebI2ahrHlhekzZF2HYmPkVw4bHda8Bja6mbaw8FVBgBHjPU8mMeDA==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.59.tgz",
+      "integrity": "sha512-Ol/JPszWZ+OZ44FOdJe35TfJ1ckG4pYaisZJ4E7PzfwfVe2ygX85C5WWR4e5L0Y1zFvzpcI7gdyC2wzcXk4Cig==",
       "dev": true,
       "optional": true,
       "peer": true
     },
     "@swc/core-linux-arm64-musl": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.49.tgz",
-      "integrity": "sha512-nlKPYMogAI3Aak6Mlkag8/2AlHAZ/DpH7RjhfMazsaGhD/sQOmYdyY9Al69ejpa419YJuREeeeLoojFlSsd30g==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.59.tgz",
+      "integrity": "sha512-PtTTtGbj9GiY5gJdoSFL2A0vL6BRaS1haAhp6g3hZvLDkTTg+rJURmzwBMMjaQlnGC62x/lLf6MoszHG/05//Q==",
       "dev": true,
       "optional": true,
       "peer": true
     },
     "@swc/core-linux-x64-gnu": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.49.tgz",
-      "integrity": "sha512-QOyeJQ6NVi73SJcizbwvIZTiGA/N+BxX9liRrvibumaQmRh8fWjJiLNsv3ODSHeuonak7E8Bf7a7NnSTyu48Mw==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.59.tgz",
+      "integrity": "sha512-XBW9AGi0YsIN76IfesnDSBn/5sjR69J75KUNte8sH6seYlHJ0/kblqUMbUcfr0CiGoJadbzAZeKZZmfN7EsHpg==",
       "dev": true,
       "optional": true,
       "peer": true
     },
     "@swc/core-linux-x64-musl": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.49.tgz",
-      "integrity": "sha512-WlDMz+SOpYC9O/ZBUw1oiyWI7HyUCMlf/HS8Fy/kRI3eGoGCUxVTCJ1mP57GdQr4Wg32Y/ZpO2KSNQFWnT8mAw==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.59.tgz",
+      "integrity": "sha512-Cy5E939SdWPQ34cg6UABNO0RyEe0FuWqzZ/GLKtK11Ir4fjttVlucZiY59uQNyUVUc8T2qE0VBFCyD/zYGuHtg==",
       "dev": true,
       "optional": true,
       "peer": true
     },
     "@swc/core-win32-arm64-msvc": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.49.tgz",
-      "integrity": "sha512-41LZOeI94Za3twib8KOIjnHYAZ+nkBFmboaREsFR1760S7jiMVywqWX8nFZvn/CXj15Fjjgdgyuig+zMREwXwQ==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.59.tgz",
+      "integrity": "sha512-z5ZJxizRvRoSAaevRIi3YjQh74OFWEIhonSDWNdqDL7RbjEivcatYcG7OikH6s+rtPhOcwNm3PbGV2Prcgh/gg==",
       "dev": true,
       "optional": true,
       "peer": true
     },
     "@swc/core-win32-ia32-msvc": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.49.tgz",
-      "integrity": "sha512-IdqLPoMKssyAoOCZdNXmnAd6/uyx+Hb9KSfZUHepZaNfwMy6J5XXrOsbYs3v53FH8MtekUUdV+mMX4me9bcv9w==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.59.tgz",
+      "integrity": "sha512-vxpsn+hrKAhi5YusQfB/JXUJJVX40rIRE/L49ilBEqdbH8Khkoego6AD+2vWqTdJcUHo1WiAIAEZ0rTsjyorLQ==",
       "dev": true,
       "optional": true,
       "peer": true
     },
     "@swc/core-win32-x64-msvc": {
-      "version": "1.3.49",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.49.tgz",
-      "integrity": "sha512-7Fqjo5pS3uIohhSbYSaR0+e/bJdxmQb4oG97FIh5qvlCCGQaQ9UiaEeYy4uK0Ad+Menum1IXCAEiG7RHcl6Eyw==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.59.tgz",
+      "integrity": "sha512-Ris/cJbURylcLwqz4RZUUBCEGsuaIHOJsvf69W5pGKHKBryVoOTNhBKpo3Km2hoAi5qFQ/ou0trAT4hBsVPZvQ==",
       "dev": true,
       "optional": true,
       "peer": true
@@ -38748,12 +38748,12 @@
       }
     },
     "@vitejs/plugin-react-swc": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.3.0.tgz",
-      "integrity": "sha512-Ycg+n2eyCOTpn/wRy+evVo859+hw7qCj9iaX5CMny6x1fx1Uoq0xBG+a98lFtwLNGfGEnpI0F26YigRuxCRkwg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.3.1.tgz",
+      "integrity": "sha512-ZoYjGxMniXP7X+5ry/W1tpY7w0OeLUEsBF5RHFPmAhpgwwNWie8OF4056MRXRi9QgvYYoZPDzdOXGK3wlCoTfQ==",
       "dev": true,
       "requires": {
-        "@swc/core": "^1.3.42"
+        "@swc/core": "^1.3.56"
       }
     },
     "@vitest/expect": {
@@ -54545,7 +54545,7 @@
         "@storybook/testing-library": "0.1.0",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
-        "@vitejs/plugin-react-swc": "^3.0.0",
+        "@vitejs/plugin-react-swc": "3.3.1",
         "autoprefixer": "10.4.14",
         "postcss": "8.4.23",
         "prop-types": "^15.8.1",


### PR DESCRIPTION
Closes #58 

Manually updating @vitejs/plugin-react-swc because #58 only updates package.lock due to unpinned version.

## TODOs

- [x] Update `@vitejs/plugin-react-swc` to latest
