### PR TITLE
Chore: set lint job resource to medium

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - persist_my_workspace
   lint:
     executor: default
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_my_workspace


### PR DESCRIPTION
## TODOs

Lately, lint started to fail [occasionally](https://app.circleci.com/pipelines/github/zenoplex/react-hooks/257/workflows/30ea1199-b0a1-4404-a185-fb239d8ba1a0/jobs/1871).
Resource is using max memory and the message `workshop:lint: Killed` could be due to OOM.


- [x] Set `lint` job `resource_class`:  `small` -> `medium`